### PR TITLE
add `receiveProofs` to storage interface

### DIFF
--- a/src/interfaces/cashu-storage.interface.ts
+++ b/src/interfaces/cashu-storage.interface.ts
@@ -29,6 +29,9 @@ export interface CashuStorage<T extends StartProofSelection> {
     options?: TransactionOptions,
   ) => Promise<void>;
 
+  /* adds proofs to the store */
+  receiveProofs: (proofs: Array<Proof>) => Promise<void>;
+
   /**
    * @returns current balance as the sum of all proofs
    */

--- a/src/stores/localstorage.ts
+++ b/src/stores/localstorage.ts
@@ -68,6 +68,17 @@ export class CashuLocalStorage implements CashuStorage<StartProofSelection> {
       throw e;
     }
   }
+  public async receiveProofs(proofs: Array<Proof>): Promise<void> {
+    const existingProofs = this.loadAllProofs();
+    const existingIds = existingProofs.map(getProofUID);
+
+    // only save proofs not already in the store
+    const newProofs = proofs.filter(
+      (p) => !existingIds.includes(getProofUID(p)),
+    );
+
+    this.saveAllProofs([...existingProofs, ...newProofs]);
+  }
 
   public async getBalance(): Promise<number> {
     return sumProofs(this.loadAllProofs());


### PR DESCRIPTION
This is useful for claiming or minting ecash.

ie.
```ts
    const { proofs: newProofs } = await this.mintProofs(
      amount,
      mintQuote.quote
    );

    await this._proofStorage.receiveProofs(newProofs);
```