### PR TITLE
Add changeset publish action

### DIFF
--- a/.github/workflows/version-or-publish.yml
+++ b/.github/workflows/version-or-publish.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm version-packages
+          publish: pnpm release
+        env:
+          HOME: ${{ github.workspace }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write .",
     "docs": "typedoc",
     "version-packages": "changeset version && pnpm install --no-frozen-lockfile && pnpm format",
-    "release": "pnpm run -r build && changeset publish"
+    "release": "pnpm build && changeset publish"
   },
   "dependencies": {
     "@changesets/cli": "^2.27.9",


### PR DESCRIPTION
This PR adds a github action that will publish the npm packages when a "Version Packages" PR from changeset-bot is merged

This only requires that a `NPM_TOKEN` secret is added to the repository secrets [here](https://github.com/gudnuf/cornucopia/settings/secrets/actions)